### PR TITLE
Updated counter_bloc.dart to work with v0.11.0 of flutter_bloc library

### DIFF
--- a/lib/counter_bloc.dart
+++ b/lib/counter_bloc.dart
@@ -15,14 +15,12 @@ class CounterBloc extends Bloc<CounterEvent, CounterState> {
   CounterState get initialState => CounterState.initial();
 
   @override
-  Stream<CounterState> mapEventToState(
-    CounterState currentState,
-    CounterEvent event,
-  ) async* {
+  Stream<CounterState> mapEventToState(CounterEvent event) async* {
+    final _currentState = currentState;
     if (event is IncrementEvent) {
-      yield CounterState(counter: currentState.counter + 1);
+      yield CounterState(counter: _currentState.counter + 1);
     } else if (event is DecrementEvent) {
-      yield CounterState(counter: currentState.counter - 1);
+      yield CounterState(counter: _currentState.counter - 1);
     }
   }
 }


### PR DESCRIPTION
The currentState in the method body is a bloc property, that's how it should be in v0.11.0 of bloc. The docs  states that currentState is a computed property.
- Per Felix, the author of the awesome `Flutter Bloc` Library :)